### PR TITLE
Cache one item at the time

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
@@ -6,6 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Secret\SecretStorageInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class SecretsListCommand extends Command
@@ -28,16 +29,18 @@ final class SecretsListCommand extends Command
     {
         $this
             ->setDescription('Lists all secrets.')
+            ->addOption('reveal', 'r', InputOption::VALUE_NONE, 'display plain text value alongside keys')
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $reveal = $input->getOption('reveal');
         $table = new Table($output);
         $table->setHeaders(['key', 'plaintext secret']);
 
-        foreach ($this->secretStorage->listSecrets() as $key => $secret) {
-            $table->addRow([$key, $secret]);
+        foreach ($this->secretStorage->listKeys() as $key) {
+            $table->addRow([$key, $reveal ? $this->secretStorage->getSecret($key) : '-']);
         }
 
         $table->render();

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1370,6 +1370,7 @@ class FrameworkExtension extends Extension
     {
         if (!$this->isConfigEnabled($container, $config)) {
             $container->removeDefinition('console.command.secrets_add');
+            $container->removeDefinition('console.command.secrets_list');
 
             return;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Secret/FilesSecretStorage.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secret/FilesSecretStorage.php
@@ -41,15 +41,14 @@ class FilesSecretStorage implements SecretStorageInterface
         unlink($this->getFilePath($key));
     }
 
-    public function listSecrets(): iterable
+    public function listKeys(): iterable
     {
         foreach (scandir($this->secretsFolder) as $fileName) {
             if ('.' === $fileName || '..' === $fileName) {
                 continue;
             }
 
-            $key = basename($fileName, '.bin');
-            yield $key => $this->getSecret($key);
+            yield basename($fileName, '.bin');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Secret/SecretStorageInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secret/SecretStorageInterface.php
@@ -10,5 +10,5 @@ interface SecretStorageInterface
 
     public function deleteSecret(string $key): void;
 
-    public function listSecrets(): iterable;
+    public function listKeys(): iterable;
 }


### PR DESCRIPTION
Following dicussion with Nicolas, this PR store one secret per item.

The list command as also been refactored (listSecrets replaced by listKeys) to avoid ot crash if a developper don't have material to uncrypt the value, and to benfit from cache.